### PR TITLE
Display alpha value properly

### DIFF
--- a/src/PlatformLayer/SDL2/SDL2PlatformLayer.bf
+++ b/src/PlatformLayer/SDL2/SDL2PlatformLayer.bf
@@ -58,6 +58,10 @@ namespace Strawberry.SDL2
 				SDL.GL_SetSwapInterval(1);
 				GL.Init(=> SdlGetProcAddress);
 
+				//We need to activate this somehwere to make use of the alpha layer
+				GL.glEnable(GL.GL_BLEND);
+				GL.glBlendFunc(GL.GL_SRC_ALPHA, GL.GL_ONE_MINUS_SRC_ALPHA);
+				
 				shader = new Shader(String[2] (
 					// vertex shader
 					"""


### PR DESCRIPTION
The alpha of textures currently only displays as black and not as see through.
This fixes that issue.

![image](https://user-images.githubusercontent.com/59422062/98572691-3136cf80-22b6-11eb-9d01-7a3c75fc1e42.png)
