### PR TITLE
Add Component Type To "componentTracker" if it does not exist.

### DIFF
--- a/src/Core/Scene.bf
+++ b/src/Core/Scene.bf
@@ -104,7 +104,6 @@ namespace Strawberry
 
 		private void TrackComponent(Component c)
 		{
-			for (let t in Tracker.AssignmentLists[c.GetType()])
 				componentTracker[t].Add(c);
 		}
 

--- a/src/Core/Scene.bf
+++ b/src/Core/Scene.bf
@@ -104,7 +104,19 @@ namespace Strawberry
 
 		private void TrackComponent(Component c)
 		{
+			for (let t in Tracker.AssignmentLists[c.GetType()]) {
+				// If component type not in tracker, add to tracker
+				var match = false;
+				for (let kvPair in componentTracker) {
+					if (kvPair.key == t) {
+						match = true;
+					}
+				}
+				if (!match) {
+					componentTracker.Add(t, new List<Component>());
+				}
 				componentTracker[t].Add(c);
+			}
 		}
 
 		private void UntrackComponent(Component c)


### PR DESCRIPTION
The application would crash because `t` did not exist in componentTracker:

`componentTracker[t].Add(c);`

I doubt who I am doing the key search is the best way as I was not sure how List.Contains worked when it needed both a key and value pair.